### PR TITLE
Bug fix for turbo links

### DIFF
--- a/app/assets/javascripts/donateForm.js
+++ b/app/assets/javascripts/donateForm.js
@@ -1,4 +1,5 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener('turbolinks:load', function() {
+  console.log("turbo loading?");
   var donateButtons = document.querySelectorAll('.donate-button')
   var modal = document.getElementById('donate-modal');
   var close = document.getElementById('close-button');


### PR DESCRIPTION
I had the script running on the 'DOMContentLoaded' event, but that doesn't work with turbolinks. Replacing it with 'turbolinks:loaded' fixed the issue. 